### PR TITLE
feat(m1): task1.5 add worker heartbeat and tests

### DIFF
--- a/backend/workers/queue.py
+++ b/backend/workers/queue.py
@@ -2,5 +2,12 @@
 from typing import Any
 
 
+HEARTBEAT_JOB_PATH = "backend.workers.tasks.worker_heartbeat"
+
+
 def enqueue_task(func_path: str, *args: Any, **kwargs: Any) -> str:
     return "job-queued"
+
+
+def enqueue_worker_heartbeat(node_id: str) -> str:
+    return enqueue_task(HEARTBEAT_JOB_PATH, node_id=node_id)

--- a/tests/test_worker_heartbeat.py
+++ b/tests/test_worker_heartbeat.py
@@ -1,0 +1,28 @@
+from datetime import datetime, timezone
+
+from backend.workers import queue, tasks
+from backend.workers.runner import run_job
+
+
+def test_worker_heartbeat_roundtrip():
+    job_id = queue.enqueue_worker_heartbeat("node-1")
+
+    assert job_id == "job-queued"
+
+    result = run_job(queue.HEARTBEAT_JOB_PATH, "node-1")
+
+    assert result["node_id"] == "node-1"
+    assert result["status"] == "healthy"
+    assert "at" in result
+
+
+def test_worker_heartbeat_respects_override_timestamp():
+    fixed_at = datetime(2025, 1, 1, 12, 0, tzinfo=timezone.utc)
+
+    result = tasks.worker_heartbeat("node-2", at=fixed_at)
+
+    assert result == {
+        "node_id": "node-2",
+        "status": "healthy",
+        "at": fixed_at.isoformat(),
+    }


### PR DESCRIPTION
Scoped change for task 1.5: add worker heartbeat job + tests.

Verification:
- PYTHONPATH="$PWD" .venv/bin/pytest -q tests/test_worker_heartbeat.py tests/test_worker_dispatcher.py tests/test_runner_helper.py tests/test_worker_queue_integration.py
- .venv/bin/flake8 backend/workers tests/test_worker_heartbeat.py