### PR TITLE
chore(m1): add minimal dispatcher stub + unit test

### DIFF
--- a/backend/workers/dispatcher.py
+++ b/backend/workers/dispatcher.py
@@ -1,0 +1,14 @@
+"""Minimal dispatcher stub for worker jobs."""
+from typing import Any, Dict
+
+from backend.workers import queue
+
+
+def route_job(job_path: str, payload: Dict[str, Any]) -> str:
+    if not isinstance(job_path, str) or not job_path.strip():
+        raise ValueError("job_path must be a non-empty string")
+
+    if not isinstance(payload, dict) or not payload:
+        raise ValueError("payload must be a non-empty dict")
+
+    return queue.enqueue_task(job_path, payload)

--- a/tests/test_dispatcher_stub.py
+++ b/tests/test_dispatcher_stub.py
@@ -1,0 +1,17 @@
+from backend.workers import dispatcher
+
+
+def test_route_job_dispatches(monkeypatch):
+    captured = {}
+
+    def fake_enqueue(job_path, payload):
+        captured["job_path"] = job_path
+        captured["payload"] = payload
+        return "queued-123"
+
+    monkeypatch.setattr("backend.workers.queue.enqueue_task", fake_enqueue)
+
+    result = dispatcher.route_job("worker.heartbeat", {"ts": 1})
+
+    assert result == "queued-123"
+    assert captured == {"job_path": "worker.heartbeat", "payload": {"ts": 1}}


### PR DESCRIPTION
Summary
Adds a minimal dispatcher stub (backend/workers/dispatcher.py) with route_job(job_path, payload) that validates inputs and delegates directly to backend.workers.queue.enqueue_task.

Details
	•	New module: dispatcher.py
	•	Logic:
	•	Ensures job_path is a non-empty string
	•	Ensures payload is a non-empty dict
	•	Delegates to enqueue_task(job_path, payload)
	•	No structural changes to worker or queue subsystems.

Tests
Unit test: tests/test_dispatcher_stub.py
	•	Monkeypatches enqueue_task
	•	Asserts correct argument forwarding
	•	Asserts returned task ID is passed through

Verification

PYTHONPATH="$PWD" .venv/bin/pytest -q tests/test_dispatcher_stub.py   → 1 passed  
.venv/bin/flake8 backend/workers/dispatcher.py tests/test_dispatcher_stub.py   → clean