### PR TITLE
chore(m1): add worker state tracker stub

### DIFF
--- a/backend/workers/worker_state.py
+++ b/backend/workers/worker_state.py
@@ -1,0 +1,41 @@
+"""In-memory worker state tracker stub for Phase 2 groundwork."""
+from __future__ import annotations
+
+from datetime import datetime
+
+_status = "offline"
+_last_heartbeat = None
+_last_job_id = None
+
+
+def set_status(status: str) -> None:
+    allowed = {"idle", "busy", "offline"}
+    if status not in allowed:
+        raise ValueError(f"status must be one of {sorted(allowed)}")
+    global _status
+    _status = status
+
+
+def get_status() -> str:
+    return _status
+
+
+def update_heartbeat(ts: datetime | None = None) -> None:
+    global _last_heartbeat
+    _last_heartbeat = ts or datetime.utcnow()
+
+
+def record_job(job_id: str) -> None:
+    if not isinstance(job_id, str) or not job_id:
+        raise ValueError("job_id must be a non-empty string")
+    global _last_job_id
+    _last_job_id = job_id
+    set_status("busy")
+
+
+def get_state() -> dict:
+    return {
+        "status": _status,
+        "last_heartbeat": _last_heartbeat,
+        "last_job_id": _last_job_id,
+    }

--- a/tests/test_worker_state.py
+++ b/tests/test_worker_state.py
@@ -1,0 +1,33 @@
+from datetime import datetime
+
+from backend.workers import worker_state
+
+
+def test_default_state():
+    state = worker_state.get_state()
+    assert state["status"] == "offline"
+    assert state["last_heartbeat"] is None
+    assert state["last_job_id"] is None
+
+
+def test_update_heartbeat_sets_timestamp():
+    worker_state.set_status("idle")
+    before = datetime.utcnow()
+    worker_state.update_heartbeat()
+    state = worker_state.get_state()
+
+    assert state["last_heartbeat"] is not None
+    assert state["last_heartbeat"] >= before
+    assert state["status"] == "idle"
+
+
+def test_record_job_sets_job_and_status():
+    worker_state.set_status("idle")
+    worker_state.update_heartbeat(datetime(2025, 1, 1))
+
+    worker_state.record_job("job-123")
+    state = worker_state.get_state()
+
+    assert state["last_job_id"] == "job-123"
+    assert state["status"] == "busy"
+    assert state["last_heartbeat"] == datetime(2025, 1, 1)


### PR DESCRIPTION
This PR introduces the initial "Worker State Tracker" stub, fully in-memory and independent of the legacy worker.

Changes:
- Added backend/workers/worker_state.py
- Tracks: status, last_heartbeat, last_job_id
- Functions: set_status, get_status, update_heartbeat, record_job, get_state
- No external dependencies beyond datetime.
- Added tests/test_worker_state.py
- Validates default state
- Validates heartbeat update
- Validates job recording + status transitions

Verification:
- Unit tests:
PYTHONPATH="/Users/bagumadavis/Desktop/bagbot" .venv/bin/pytest -q tests/test_worker_state.py → 3 passed
- Lint:
.venv/bin/flake8 backend/workers/worker_state.py tests/test_worker_state.py → clean

No integrations changed; safe, isolated addition.