### PR TITLE
docs(m1): job envelope contract + test (task 1.8)

### DIFF
--- a/docs/job_envelope.md
+++ b/docs/job_envelope.md
@@ -1,0 +1,117 @@
+# Worker job envelope contract
+
+**Purpose:** canonical shape for worker job messages flowing through the queue and reported to clients. No runtime code change here — contract + expectations only.
+
+---
+
+## Envelope shape (JSON)
+
+```json
+{
+  "job_id": "<string>",            // unique id from the queue
+  "job_path": "backend.workers.tasks.<fn>",
+  "args": [/* positional args */],
+  "kwargs": { /* keyword args */ },
+  "state": "enqueued|running|done|error",
+  "ts_enqueued": 1672531200,         // epoch seconds
+  "ts_started": 1672531201,          // optional
+  "ts_finished": 1672531205,         // optional
+  "error": null                      // optional string when state=error
+}
+```
+
+- `job_id`: required string (opaque queue id).
+- `job_path`: required string (fully-qualified callable path).
+- `args`/`kwargs`: required; may be empty lists/dicts; must be JSON-serializable.
+- `state`: required; one of `enqueued`, `running`, `done`, `error`.
+- `ts_enqueued`: required epoch seconds (int).
+- `ts_started`/`ts_finished`: optional epoch seconds; include when known.
+- `error`: optional string describing failure; present when `state=error`.
+
+Timestamps use **epoch seconds (int)**. If you add ISO8601 later, emit both for one release cycle (compatibility rule below).
+
+---
+
+## Lifecycle examples
+
+`enqueued`
+
+```json
+{
+  "job_id": "job-123",
+  "job_path": "backend.workers.tasks.worker_heartbeat",
+  "args": [],
+  "kwargs": {"timestamp": 1672531200},
+  "state": "enqueued",
+  "ts_enqueued": 1672531200
+}
+```
+
+`running`
+
+```json
+{
+  "job_id": "job-123",
+  "job_path": "backend.workers.tasks.worker_heartbeat",
+  "args": [],
+  "kwargs": {"timestamp": 1672531200},
+  "state": "running",
+  "ts_enqueued": 1672531200,
+  "ts_started": 1672531201
+}
+```
+
+`done`
+
+```json
+{
+  "job_id": "job-123",
+  "job_path": "backend.workers.tasks.worker_heartbeat",
+  "args": [],
+  "kwargs": {"timestamp": 1672531200},
+  "state": "done",
+  "ts_enqueued": 1672531200,
+  "ts_started": 1672531201,
+  "ts_finished": 1672531205
+}
+```
+
+`error`
+
+```json
+{
+  "job_id": "job-123",
+  "job_path": "backend.workers.tasks.worker_heartbeat",
+  "args": [],
+  "kwargs": {"timestamp": 1672531200},
+  "state": "error",
+  "ts_enqueued": 1672531200,
+  "ts_started": 1672531201,
+  "ts_finished": 1672531202,
+  "error": "Timeout talking to worker"
+}
+```
+
+---
+
+## Compatibility rules (frontend/backends)
+
+- Additive changes only: prefer adding optional fields rather than changing required ones.
+- Consumers should tolerate extra keys in the envelope.
+- If adding ISO8601 timestamps later, emit both epoch (`ts_*`) and ISO fields for one release cycle.
+- Keep `state` values stable; if introducing new states, announce and document.
+
+---
+
+## Validation notes
+
+- All fields must be JSON-serializable (no datetimes/bytes; use epoch ints).
+- `job_path` must be a non-empty string.
+- `args` and `kwargs` must be present (may be empty), never omitted.
+- `error` should be provided when `state=error`; otherwise may be null/omitted.
+
+---
+
+## Change log
+
+- v1.0 — initial job envelope contract (enqueued, running, done, error).

--- a/tests/test_job_envelope.py
+++ b/tests/test_job_envelope.py
@@ -1,0 +1,42 @@
+import json
+from typing import Any, Dict
+
+
+def make_job_envelope(state: str) -> Dict[str, Any]:
+    return {
+        "job_id": "job-123",
+        "job_path": "backend.workers.tasks.worker_heartbeat",
+        "args": [],
+        "kwargs": {"timestamp": 1672531200},
+        "state": state,
+        "ts_enqueued": 1672531200,
+        "ts_started": 1672531201,
+        "ts_finished": 1672531205,
+        "error": None if state != "error" else "Timeout talking to worker",
+    }
+
+
+def test_job_envelope_shape_enqueued():
+    env = make_job_envelope("enqueued")
+    assert env["job_id"]
+    assert env["job_path"]
+    assert isinstance(env["args"], list)
+    assert isinstance(env["kwargs"], dict)
+    assert env["state"] == "enqueued"
+    assert isinstance(env["ts_enqueued"], int)
+    json.dumps(env)
+
+
+def test_job_envelope_shape_done_is_serializable():
+    env = make_job_envelope("done")
+    assert env["state"] == "done"
+    assert isinstance(env["ts_started"], int)
+    assert isinstance(env["ts_finished"], int)
+    json.dumps(env)
+
+
+def test_job_envelope_error_carries_message():
+    env = make_job_envelope("error")
+    assert env["state"] == "error"
+    assert env["error"]
+    json.dumps(env)


### PR DESCRIPTION
Add worker job envelope contract + shape test.

Changes:
- docs/job_envelope.md: canonical worker job envelope (job_id, job_path, args/kwargs, state, ts_*), lifecycle examples (enqueued/running/done/error), compatibility rules.
- tests/test_job_envelope.py: builds a fake job envelope, asserts required fields/types, and JSON-serializability.

Notes:
- Doc only; no runtime queue changes.
- Timestamps use epoch seconds (documented). If ISO is added later, emit both for one release cycle.

Verification:
- PYTHONPATH="/Users/bagumadavis/Desktop/bagbot" .venv/bin/pytest -q tests/test_job_envelope.py
- .venv/bin/flake8 tests/test_job_envelope.py