### PR TITLE
feat(m1): worker to websocket relay (task 1.9)

### DIFF
--- a/backend/workers/events.py
+++ b/backend/workers/events.py
@@ -1,0 +1,72 @@
+from __future__ import annotations
+
+import json
+import time
+from typing import Any, Dict, Optional
+
+from backend.ws.manager import websocket_broadcast
+
+SIGNALS_CHANNEL = "signals"
+
+
+def _now_ms() -> int:
+    return int(time.time() * 1000)
+
+
+async def broadcast_worker_heartbeat(
+    worker_id: str,
+    ts: Optional[int] = None,
+) -> Dict[str, Any]:
+    """Broadcast worker heartbeat event and return the envelope."""
+
+    timestamp = ts or _now_ms()
+    envelope: Dict[str, Any] = {
+        "channel": SIGNALS_CHANNEL,
+        "event": "worker.heartbeat",
+        "payload": {"worker_id": worker_id, "ts": timestamp},
+        "ts": timestamp,
+    }
+    # use existing broadcast helper
+    await websocket_broadcast(
+        channel=SIGNALS_CHANNEL,
+        event="worker.heartbeat",
+        payload=envelope["payload"],
+    )
+    # sanity: ensure JSON-serializable
+    json.dumps(envelope)
+    return envelope
+
+
+async def broadcast_job_event(
+    job_id: str,
+    job_path: str,
+    state: str,
+    payload: Optional[Dict[str, Any]] = None,
+    ts: Optional[int] = None,
+) -> Dict[str, Any]:
+    """Broadcast worker job lifecycle event and return the envelope."""
+
+    timestamp = ts or _now_ms()
+    job_payload: Dict[str, Any] = {
+        "job_id": job_id,
+        "job_path": job_path,
+        "state": state,
+        "ts": timestamp,
+    }
+    if payload:
+        job_payload.update(payload)
+
+    event_name = f"worker.job.{state}"
+    envelope: Dict[str, Any] = {
+        "channel": SIGNALS_CHANNEL,
+        "event": event_name,
+        "payload": job_payload,
+        "ts": timestamp,
+    }
+    await websocket_broadcast(
+        channel=SIGNALS_CHANNEL,
+        event=event_name,
+        payload=job_payload,
+    )
+    json.dumps(envelope)
+    return envelope

--- a/backend/workers/queue.py
+++ b/backend/workers/queue.py
@@ -1,14 +1,44 @@
 """Queue stubs for tests."""
 from __future__ import annotations
 
+import asyncio
+import time
 from typing import Any
+
+from backend.workers.events import broadcast_job_event
 
 
 HEARTBEAT_JOB_PATH = "backend.workers.tasks.worker_heartbeat"
 
 
 def enqueue_task(func_path: str, *args: Any, **kwargs: Any) -> str:
-    return "job-queued"
+    job_id = "job-queued"
+    ts_enqueued = int(time.time() * 1000)
+
+    try:
+        loop = asyncio.get_running_loop()
+    except RuntimeError:
+        asyncio.run(
+            broadcast_job_event(
+                job_id,
+                func_path,
+                "enqueued",
+                payload={"ts_enqueued": ts_enqueued},
+                ts=ts_enqueued,
+            )
+        )
+    else:
+        loop.create_task(
+            broadcast_job_event(
+                job_id,
+                func_path,
+                "enqueued",
+                payload={"ts_enqueued": ts_enqueued},
+                ts=ts_enqueued,
+            )
+        )
+
+    return job_id
 
 
 def enqueue_worker_heartbeat(

--- a/backend/workers/runner.py
+++ b/backend/workers/runner.py
@@ -1,7 +1,63 @@
+from __future__ import annotations
+
+import asyncio
 import importlib
+import time
+from typing import Any
+
+from backend.workers.events import broadcast_job_event
 
 
-def run_job(path: str, *args, **kwargs):
+def _schedule(coro: Any) -> None:
+    """Await coroutine now or schedule if an event loop is already running."""
+
+    try:
+        loop = asyncio.get_running_loop()
+    except RuntimeError:
+        asyncio.run(coro)
+    else:
+        loop.create_task(coro)
+
+
+def run_job(path: str, *args, job_id: str | None = None, **kwargs):
+    job_identifier = job_id or kwargs.pop("job_id", "job-inline")
+
+    ts_started = int(time.time() * 1000)
+    _schedule(
+        broadcast_job_event(
+            job_identifier,
+            path,
+            "started",
+            payload={"ts_started": ts_started},
+            ts=ts_started,
+        )
+    )
+
     module_path, fn = path.rsplit(".", 1)
     mod = importlib.import_module(module_path)
-    return getattr(mod, fn)(*args, **kwargs)
+    try:
+        result = getattr(mod, fn)(*args, **kwargs)
+    except Exception as exc:  # pragma: no cover - captured by tests
+        ts_finished = int(time.time() * 1000)
+        _schedule(
+            broadcast_job_event(
+                job_identifier,
+                path,
+                "error",
+                payload={"error": str(exc), "ts_finished": ts_finished},
+                ts=ts_finished,
+            )
+        )
+        raise
+
+    ts_finished = int(time.time() * 1000)
+    _schedule(
+        broadcast_job_event(
+            job_identifier,
+            path,
+            "done",
+            payload={"ts_finished": ts_finished},
+            ts=ts_finished,
+        )
+    )
+    return result

--- a/tests/test_worker_event_integration.py
+++ b/tests/test_worker_event_integration.py
@@ -1,0 +1,72 @@
+from __future__ import annotations
+
+import asyncio
+import json
+import pytest
+
+from backend.workers import queue
+from backend.workers.runner import run_job
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+@pytest.mark.anyio("asyncio")
+async def test_enqueue_and_runner_emit_job_events_and_heartbeat(monkeypatch):
+    events = []
+
+    async def fake_ws(channel: str, event: str, payload=None, **kwargs):
+        events.append({"channel": channel, "event": event, "payload": payload})
+
+    monkeypatch.setattr("backend.workers.events.websocket_broadcast", fake_ws)
+
+    job_id = queue.enqueue_worker_heartbeat("node-int")
+
+    # allow enqueued broadcast to flush
+    await asyncio.sleep(0)
+
+    result = run_job(queue.HEARTBEAT_JOB_PATH, "node-int", job_id=job_id)
+    assert result["status"] == "healthy"
+
+    # allow scheduled broadcasts to run
+    await asyncio.sleep(0)
+
+    event_names = [ev["event"] for ev in events]
+
+    assert "worker.job.enqueued" in event_names
+    assert "worker.job.started" in event_names
+    assert "worker.job.done" in event_names
+    assert "worker.heartbeat" in event_names
+
+    # ordering: started happens before done
+    assert event_names.index("worker.job.started") < event_names.index(
+        "worker.job.done"
+    )
+
+    heartbeat = next(ev for ev in events if ev["event"] == "worker.heartbeat")
+    assert heartbeat["payload"]["worker_id"] == "node-int"
+    assert isinstance(heartbeat["payload"]["ts"], int)
+
+    started_payload = next(
+        ev["payload"] for ev in events if ev["event"] == "worker.job.started"
+    )
+    done_payload = next(
+        ev["payload"] for ev in events if ev["event"] == "worker.job.done"
+    )
+
+    assert started_payload["job_id"] == job_id
+    assert started_payload["job_path"] == queue.HEARTBEAT_JOB_PATH
+    assert done_payload["job_id"] == job_id
+    assert done_payload["job_path"] == queue.HEARTBEAT_JOB_PATH
+
+    # ensure payloads are JSON-serializable
+    for envelope in events:
+        json.dumps(
+            {
+                "channel": envelope["channel"],
+                "event": envelope["event"],
+                "payload": envelope["payload"],
+            }
+        )

--- a/tests/test_worker_events.py
+++ b/tests/test_worker_events.py
@@ -1,0 +1,77 @@
+from __future__ import annotations
+
+import json
+import pytest
+
+from backend.workers.events import (
+    broadcast_job_event,
+    broadcast_worker_heartbeat,
+)
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+@pytest.mark.anyio("asyncio")
+async def test_broadcast_worker_heartbeat_builds_correct_envelope(monkeypatch):
+    calls = []
+
+    async def fake_ws(channel: str, event: str, payload=None, **kwargs):
+        calls.append({"channel": channel, "event": event, "payload": payload})
+
+    monkeypatch.setattr("backend.workers.events.websocket_broadcast", fake_ws)
+
+    envelope = await broadcast_worker_heartbeat("worker-1", ts=123)
+
+    assert envelope["channel"] == "signals"
+    assert envelope["event"] == "worker.heartbeat"
+    assert envelope["payload"]["worker_id"] == "worker-1"
+    assert envelope["payload"]["ts"] == 123
+    assert isinstance(envelope["ts"], int)
+    json.dumps(envelope)
+
+    assert calls == [
+        {
+            "channel": "signals",
+            "event": "worker.heartbeat",
+            "payload": {"worker_id": "worker-1", "ts": 123},
+        }
+    ]
+
+
+@pytest.mark.anyio("asyncio")
+async def test_broadcast_job_events_emits_expected_shape(monkeypatch):
+    calls = []
+
+    async def fake_ws(channel: str, event: str, payload=None, **kwargs):
+        calls.append({"channel": channel, "event": event, "payload": payload})
+
+    monkeypatch.setattr("backend.workers.events.websocket_broadcast", fake_ws)
+
+    envelope = await broadcast_job_event(
+        "job-1",
+        "backend.workers.tasks.worker_heartbeat",
+        "started",
+        payload={"ts_started": 456},
+        ts=456,
+    )
+
+    assert envelope["channel"] == "signals"
+    assert envelope["event"] == "worker.job.started"
+    payload = envelope["payload"]
+    assert payload["job_id"] == "job-1"
+    assert payload["job_path"] == "backend.workers.tasks.worker_heartbeat"
+    assert payload["state"] == "started"
+    assert payload["ts"] == 456
+    assert payload["ts_started"] == 456
+    json.dumps(envelope)
+
+    assert calls == [
+        {
+            "channel": "signals",
+            "event": "worker.job.started",
+            "payload": payload,
+        }
+    ]


### PR DESCRIPTION
Summary:
- Implement worker→WebSocket relay for worker.heartbeat and worker.job.* events.
- Instrumented queue/runner/tasks so they emit event envelopes.
- Added tests: test_worker_events.py and test_worker_event_integration.py.

Verification:
- PYTHONPATH="$PWD" .venv/bin/pytest -q tests/test_worker_event_integration.py tests/test_worker_events.py tests/test_worker_dispatcher.py → all passed.
- flake8 clean for touched files (legacy test files have existing issues).

Notes:
- No runtime-breaking changes; all updates are isolated to worker event path.