### PR TITLE
feat(m1): redis retry worker + queue monitor (task 1.12)

### DIFF
--- a/backend/workers/metrics.py
+++ b/backend/workers/metrics.py
@@ -19,6 +19,14 @@ class Histogram:
         self.values.append(value)
 
 
+class Gauge:
+    def __init__(self) -> None:
+        self.value: float | int = 0
+
+    def set(self, value: float | int) -> None:
+        self.value = value
+
+
 class Metrics:
     def __init__(self) -> None:
         self.worker_jobs_enqueued_total = Counter()
@@ -27,6 +35,11 @@ class Metrics:
         self.worker_jobs_failed_total = Counter()
         self.worker_jobs_retried_total = Counter()
         self.worker_job_duration_seconds = Histogram()
+        self.worker_retry_triggered_total = Counter()
+        self.worker_queue_length = Gauge()
+        self.worker_jobs_running = Gauge()
+        self.worker_jobs_stuck = Gauge()
+        self.worker_latest_heartbeat_age_ms = Gauge()
 
 
 default_metrics = Metrics()

--- a/backend/workers/retry_worker.py
+++ b/backend/workers/retry_worker.py
@@ -1,0 +1,108 @@
+from __future__ import annotations
+
+import asyncio
+import time
+from typing import Any, Dict, Optional
+
+from backend.workers import job_store, metrics
+from backend.workers.redis_job_store import RedisJobStore
+from backend.workers.runner import run_job_async
+
+
+async def _maybe_await(value):
+    if asyncio.iscoroutine(value) or asyncio.isfuture(value):
+        return await value
+    return value
+
+
+def _now_ms() -> int:
+    return int(time.time() * 1000)
+
+
+async def redis_retry_worker(
+    store: Optional[Any] = None,
+    *,
+    poll_interval_ms: int = 0,
+    loop: Optional[asyncio.AbstractEventLoop] = None,
+) -> None:
+    """Drain due retries from RedisJobStore and re-run them.
+
+    Stops when the retry set is drained or when cancelled.
+    """
+
+    store = store or job_store.default_store
+    loop = loop or asyncio.get_event_loop()
+
+    while True:
+        now_ms = _now_ms()
+        jobs = await _maybe_await(store.next_retry_jobs(now_ms))
+        if not jobs:
+            break
+
+        for job_id, job in jobs:
+            job_copy: Dict[str, Any] = dict(job)
+            job_copy["job_id"] = job_id
+
+            claimed = await _maybe_await(store.claim(job_id))
+            if not claimed:
+                continue
+
+            attempts = await _maybe_await(store.attempts(job_id))
+            job_copy["attempts"] = attempts
+            metrics.default_metrics.worker_retry_triggered_total.inc()
+            await run_job_async(job_copy, loop=loop, skip_claim=True)
+
+        if poll_interval_ms:
+            await asyncio.sleep(poll_interval_ms / 1000.0)
+
+
+async def redis_queue_monitor(
+    store: Optional[Any] = None,
+    *,
+    stale_ms: int = 300_000,
+) -> Dict[str, int]:
+    """Collect queue stats from RedisJobStore and publish metrics."""
+
+    store = store or job_store.default_store
+    if not isinstance(store, RedisJobStore):
+        return {}
+
+    redis = store._redis  # type: ignore[attr-defined]
+    now_ms = _now_ms()
+    queue_len = 0
+    running = 0
+    stuck = 0
+    latest_update = 0
+
+    pattern = f"{store._namespace}:*"  # type: ignore[attr-defined]
+    async for key in redis.scan_iter(match=pattern):
+        if str(key).endswith("retry_zset"):
+            continue
+        data = await redis.hgetall(key)
+        state = data.get("state")
+        updated_raw = data.get("updated_at")
+        updated_at = int(float(updated_raw)) if updated_raw else 0
+
+        if state == "enqueued":
+            queue_len += 1
+        if state == "running":
+            running += 1
+            if updated_at:
+                age = now_ms - updated_at
+                if age > stale_ms:
+                    stuck += 1
+                latest_update = max(latest_update, updated_at)
+
+    heartbeat_age = now_ms - latest_update if latest_update else 0
+
+    metrics.default_metrics.worker_queue_length.set(queue_len)
+    metrics.default_metrics.worker_jobs_running.set(running)
+    metrics.default_metrics.worker_jobs_stuck.set(stuck)
+    metrics.default_metrics.worker_latest_heartbeat_age_ms.set(heartbeat_age)
+
+    return {
+        "queue_len": queue_len,
+        "running": running,
+        "stuck": stuck,
+        "heartbeat_age_ms": heartbeat_age,
+    }

--- a/tests/test_redis_queue_monitor.py
+++ b/tests/test_redis_queue_monitor.py
@@ -1,0 +1,62 @@
+import time
+
+import pytest
+import fakeredis.aioredis
+
+from backend.workers import job_store, metrics
+from backend.workers.metrics import Metrics
+from backend.workers.redis_job_store import RedisJobStore
+from backend.workers.retry_worker import redis_queue_monitor
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+@pytest.fixture
+async def redis_store(monkeypatch):
+    client = fakeredis.aioredis.FakeRedis(decode_responses=True)
+    store = RedisJobStore(client=client)
+    monkeypatch.setattr(job_store, "default_store", store)
+    yield store
+    await client.flushall()
+    await client.close()
+
+
+@pytest.fixture
+async def test_metrics(monkeypatch):
+    m = Metrics()
+    monkeypatch.setattr(metrics, "default_metrics", m)
+    return m
+
+
+@pytest.mark.anyio("asyncio")
+async def test_redis_queue_monitor_counts(redis_store, test_metrics):
+    now_ms = int(time.time() * 1000)
+
+    # enqueued job
+    await redis_store._redis.hset(  # type: ignore[attr-defined]
+        redis_store._job_key("j1"),  # type: ignore[attr-defined]
+        mapping={"state": "enqueued", "updated_at": now_ms},
+    )
+    # running fresh
+    await redis_store._redis.hset(  # type: ignore[attr-defined]
+        redis_store._job_key("j2"),  # type: ignore[attr-defined]
+        mapping={"state": "running", "updated_at": now_ms - 10_000},
+    )
+    # running stuck
+    await redis_store._redis.hset(  # type: ignore[attr-defined]
+        redis_store._job_key("j3"),  # type: ignore[attr-defined]
+        mapping={"state": "running", "updated_at": now_ms - 400_000},
+    )
+
+    stats = await redis_queue_monitor(redis_store, stale_ms=300_000)
+
+    assert stats["queue_len"] == 1
+    assert stats["running"] == 2
+    assert stats["stuck"] == 1
+    assert test_metrics.worker_queue_length.value == 1
+    assert test_metrics.worker_jobs_running.value == 2
+    assert test_metrics.worker_jobs_stuck.value == 1
+    assert test_metrics.worker_latest_heartbeat_age_ms.value >= 0

--- a/tests/test_redis_retry_worker.py
+++ b/tests/test_redis_retry_worker.py
@@ -1,0 +1,69 @@
+import pytest
+import fakeredis.aioredis
+
+from backend.workers import job_store, metrics, runner
+from backend.workers.metrics import Metrics
+from backend.workers.redis_job_store import RedisJobStore
+from backend.workers.retry_worker import redis_retry_worker
+
+_calls = []
+
+
+def _dummy_job():
+    _calls.append("ran")
+    return "ok"
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+@pytest.fixture
+async def redis_store(monkeypatch):
+    client = fakeredis.aioredis.FakeRedis(decode_responses=True)
+    store = RedisJobStore(client=client)
+    monkeypatch.setattr(job_store, "default_store", store)
+    monkeypatch.setattr(runner, "default_store", store)
+    yield store
+    await client.flushall()
+    await client.close()
+
+
+@pytest.fixture
+async def test_metrics(monkeypatch):
+    m = Metrics()
+    monkeypatch.setattr(metrics, "default_metrics", m)
+    monkeypatch.setattr(runner, "default_metrics", m)
+    return m
+
+
+@pytest.mark.anyio("asyncio")
+async def test_redis_retry_worker_runs_due_jobs(
+    monkeypatch, redis_store, test_metrics
+):
+    _calls.clear()
+
+    async def fake_broadcast(*args, **kwargs):
+        return {}
+
+    monkeypatch.setattr(
+        "backend.workers.runner.broadcast_job_event", fake_broadcast
+    )
+
+    job_id = "job-retry"
+    job_payload = {
+        "job_id": job_id,
+        "job_path": f"{__name__}._dummy_job",
+        "args": [],
+        "kwargs": {},
+    }
+
+    await redis_store.set_last_job(job_id, job_payload)
+    await redis_store.schedule_retry(job_id, epoch_ms=1)
+
+    await redis_retry_worker(redis_store)
+
+    assert _calls == ["ran"]
+    assert test_metrics.worker_retry_triggered_total.count == 1
+    assert await redis_store.get_state(job_id) == "done"


### PR DESCRIPTION
Summary
	•	Added redis_retry_worker: a distributed async worker that polls Redis for due retries, claims eligible jobs, executes them, and updates retry metrics.
	•	Added redis_queue_monitor: monitors Redis-backed job queue depth, stale/running jobs, and heartbeat age, exporting gauges for observability.
	•	Updated metrics and runner wiring to support retry + monitor loops, including skip-claim behavior and async store operations.
	•	Added new tests:
	•	test_redis_retry_worker.py
	•	test_redis_queue_monitor.py
	•	No behavioral change to the in-memory job store; Redis activation requires environment variables (JOB_STORE=redis, REDIS_URL).