### PR TITLE
feat(m1): wire WorkerCoordinator + graceful shutdown (entrypoint + tests)

### DIFF
--- a/backend/workers/entry.py
+++ b/backend/workers/entry.py
@@ -1,0 +1,79 @@
+from __future__ import annotations
+
+import asyncio
+import logging
+import signal
+import uuid
+from typing import Optional
+
+from backend.workers import job_store
+from backend.workers.orchestration import WorkerCoordinator
+from backend.workers.runner import runner_loop
+
+logger = logging.getLogger(__name__)
+
+
+async def _run_worker(
+    worker_id: Optional[str] = None,
+    redis_url: Optional[str] = None,
+    *,
+    shutdown_event: Optional[asyncio.Event] = None,
+    heartbeat_interval: float = 5.0,
+    poll_interval_ms: int = 500,
+) -> None:
+    coord = WorkerCoordinator(redis_url=redis_url)
+    worker_identifier = worker_id or f"worker-{uuid.uuid4().hex[:8]}"
+    await coord.register(worker_identifier)
+
+    stop_event = shutdown_event or asyncio.Event()
+
+    hb_task = asyncio.create_task(
+        coord.heartbeat_loop(
+            worker_identifier,
+            interval=heartbeat_interval,
+            shutdown_event=stop_event,
+        )
+    )
+
+    runner_task = asyncio.create_task(
+        runner_loop(
+            shutdown_event=stop_event,
+            store=job_store.default_store,
+            poll_interval_ms=poll_interval_ms,
+        )
+    )
+
+    loop = asyncio.get_running_loop()
+    try:
+        loop.add_signal_handler(signal.SIGINT, stop_event.set)
+        loop.add_signal_handler(signal.SIGTERM, stop_event.set)
+    except NotImplementedError:
+        logger.debug(
+            "Signal handler registration not supported on this platform"
+        )
+
+    try:
+        await stop_event.wait()
+        logger.info("Shutdown signal received, starting graceful shutdown")
+    finally:
+        stop_event.set()
+        try:
+            await asyncio.wait_for(runner_task, timeout=10)
+        except asyncio.TimeoutError:
+            logger.warning("Runner did not exit in time, cancelling")
+            runner_task.cancel()
+            await asyncio.gather(runner_task, return_exceptions=True)
+
+        hb_task.cancel()
+        await asyncio.gather(hb_task, return_exceptions=True)
+        await coord.deregister(worker_identifier)
+        await coord.close()
+        logger.info("Worker shutdown complete")
+
+
+def main() -> None:
+    asyncio.run(_run_worker())
+
+
+if __name__ == "__main__":
+    main()

--- a/backend/workers/orchestration.py
+++ b/backend/workers/orchestration.py
@@ -1,0 +1,188 @@
+from __future__ import annotations
+
+import asyncio
+import time
+from typing import Any, Awaitable, Callable, Dict, List, Optional
+
+from redis.asyncio import Redis
+
+
+def _now_ms() -> int:
+    return int(time.time() * 1000)
+
+
+class WorkerCoordinator:
+    """Redis-backed worker registry and coordination helpers."""
+
+    def __init__(
+        self,
+        *,
+        redis_url: str | None = None,
+        client: Optional[Redis] = None,
+        namespace: str = "worker",
+        ttl_seconds: float = 60,
+    ) -> None:
+        if client is not None:
+            self._redis = client
+            self._own_client = False
+        else:
+            self._redis = Redis.from_url(
+                redis_url or "redis://localhost:6379/0",
+                decode_responses=True,
+            )
+            self._own_client = True
+        self._namespace = namespace
+        self._workers_key = f"{namespace}:workers"
+        self._ttl_ms = int(ttl_seconds * 1000)
+
+    def _worker_key(self, worker_id: str) -> str:
+        return f"{self._namespace}:{worker_id}:info"
+
+    def _shutdown_key(self, worker_id: str) -> str:
+        return f"{self._namespace}:{worker_id}:shutdown"
+
+    async def register(
+        self,
+        worker_id: str,
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> None:
+        now = _now_ms()
+        mapping: Dict[str, Any] = {
+            "worker_id": worker_id,
+            "status": "online",
+            "last_seen_ms": now,
+        }
+        if metadata:
+            mapping.update({f"meta_{k}": v for k, v in metadata.items()})
+
+        pipe = self._redis.pipeline()
+        pipe.sadd(self._workers_key, worker_id)
+        pipe.hset(self._worker_key(worker_id), mapping=mapping)
+        pipe.pexpire(self._worker_key(worker_id), self._ttl_ms)
+        await pipe.execute()
+
+    async def heartbeat(self, worker_id: str) -> None:
+        await self._redis.hset(
+            self._worker_key(worker_id),
+            mapping={"last_seen_ms": _now_ms(), "status": "online"},
+        )
+        await self._redis.pexpire(self._worker_key(worker_id), self._ttl_ms)
+
+    async def heartbeat_loop(
+        self,
+        worker_id: str,
+        *,
+        interval: float = 5.0,
+        shutdown_event: Optional[asyncio.Event] = None,
+    ) -> None:
+        """Send periodic heartbeats until shutdown_event is set."""
+
+        poll_ms = int(interval * 1000)
+        while True:
+            if shutdown_event and shutdown_event.is_set():
+                break
+            await self.heartbeat(worker_id)
+            should_stop = await _wait_or_timeout(poll_ms, shutdown_event)
+            if should_stop:
+                break
+
+    async def deregister(self, worker_id: str) -> None:
+        pipe = self._redis.pipeline()
+        pipe.srem(self._workers_key, worker_id)
+        pipe.delete(self._worker_key(worker_id))
+        pipe.delete(self._shutdown_key(worker_id))
+        await pipe.execute()
+
+    async def active_workers(self) -> List[str]:
+        await self.cleanup_stale()
+        members = await self._redis.smembers(self._workers_key)
+        return list(members)
+
+    async def get_worker(self, worker_id: str) -> Dict[str, Any]:
+        return await self._redis.hgetall(self._worker_key(worker_id))
+
+    async def cleanup_stale(self) -> List[str]:
+        now = _now_ms()
+        stale: List[str] = []
+        workers = await self._redis.smembers(self._workers_key)
+        for worker_id in workers:
+            data = await self._redis.hgetall(self._worker_key(worker_id))
+            last_seen = int(data.get("last_seen_ms", 0)) if data else 0
+            if not data or now - last_seen > self._ttl_ms:
+                stale.append(worker_id)
+                await self._redis.delete(self._worker_key(worker_id))
+                await self._redis.delete(self._shutdown_key(worker_id))
+                await self._redis.srem(self._workers_key, worker_id)
+        return stale
+
+    async def mark_shutdown(
+        self,
+        worker_id: str,
+        *,
+        ttl_seconds: Optional[int] = None,
+    ) -> None:
+        ttl_ms = int((ttl_seconds or self._ttl_ms / 1000) * 1000)
+        await self._redis.set(self._shutdown_key(worker_id), "1", px=ttl_ms)
+
+    async def clear_shutdown(self, worker_id: str) -> None:
+        await self._redis.delete(self._shutdown_key(worker_id))
+
+    async def should_shutdown(self, worker_id: str) -> bool:
+        flag = await self._redis.get(self._shutdown_key(worker_id))
+        return bool(flag)
+
+    async def close(self) -> None:
+        if getattr(self, "_own_client", False):
+            await self._redis.close()
+
+
+async def _wait_or_timeout(
+    poll_interval_ms: int,
+    shutdown_event: Optional[asyncio.Event],
+) -> bool:
+    if poll_interval_ms <= 0:
+        return False
+    if shutdown_event is None:
+        await asyncio.sleep(poll_interval_ms / 1000.0)
+        return False
+    try:
+        await asyncio.wait_for(
+            shutdown_event.wait(), timeout=poll_interval_ms / 1000.0
+        )
+        return True
+    except asyncio.TimeoutError:
+        return False
+
+
+async def worker_loop(
+    run_once: Callable[[], Awaitable[Any]],
+    *,
+    poll_interval_ms: int = 1000,
+    shutdown_event: Optional[asyncio.Event] = None,
+) -> None:
+    """Generic worker loop that can be stopped via an asyncio.Event."""
+
+    while True:
+        if shutdown_event and shutdown_event.is_set():
+            break
+        await run_once()
+        should_stop = await _wait_or_timeout(poll_interval_ms, shutdown_event)
+        if should_stop:
+            break
+
+
+async def retry_worker_loop(
+    run_once: Callable[[], Awaitable[Any]],
+    *,
+    poll_interval_ms: int = 500,
+    shutdown_event: Optional[asyncio.Event] = None,
+) -> None:
+    """Loop runner for retry/monitor workers with graceful shutdown."""
+
+    while True:
+        if shutdown_event and shutdown_event.is_set():
+            break
+        await run_once()
+        should_stop = await _wait_or_timeout(poll_interval_ms, shutdown_event)
+        if should_stop:
+            break

--- a/tests/test_entry_shutdown.py
+++ b/tests/test_entry_shutdown.py
@@ -1,0 +1,63 @@
+import asyncio
+
+import pytest
+
+from backend.workers import entry
+from backend.workers.entry import _run_worker
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+@pytest.mark.anyio("asyncio")
+async def test_entry_shutdown(monkeypatch):
+    calls = {"register": 0, "heartbeat": 0, "deregister": 0, "runner": 0}
+
+    class FakeCoord:
+        def __init__(self, *args, **kwargs):
+            self.store = object()
+
+        async def register(self, worker_id):
+            calls["register"] += 1
+            self.worker_id = worker_id
+
+        async def heartbeat_loop(self, worker_id, interval, shutdown_event):
+            while not shutdown_event.is_set():
+                calls["heartbeat"] += 1
+                await asyncio.sleep(0.01)
+
+        async def deregister(self, worker_id):
+            calls["deregister"] += 1
+
+        async def close(self):
+            calls["closed"] = True
+
+    async def fake_runner_loop(**kwargs):
+        shutdown_event: asyncio.Event = kwargs["shutdown_event"]
+        calls["runner"] += 1
+        while not shutdown_event.is_set():
+            await asyncio.sleep(0.01)
+
+    monkeypatch.setattr(entry, "WorkerCoordinator", FakeCoord)
+    monkeypatch.setattr(entry, "runner_loop", fake_runner_loop)
+
+    stop_event = asyncio.Event()
+    task = asyncio.create_task(
+        _run_worker(
+            worker_id="worker-test",
+            shutdown_event=stop_event,
+            heartbeat_interval=0.01,
+            poll_interval_ms=10,
+        )
+    )
+
+    await asyncio.sleep(0.05)
+    stop_event.set()
+    await asyncio.wait_for(task, timeout=1.0)
+
+    assert calls["register"] == 1
+    assert calls["deregister"] == 1
+    assert calls["runner"] >= 1
+    assert calls["heartbeat"] >= 1

--- a/tests/test_worker_orchestration.py
+++ b/tests/test_worker_orchestration.py
@@ -1,0 +1,126 @@
+import asyncio
+
+import fakeredis.aioredis
+import pytest
+
+from backend.workers.orchestration import WorkerCoordinator, worker_loop
+from backend.workers.redis_job_store import RedisJobStore
+from backend.workers.retry_worker import (
+    redis_queue_monitor_loop,
+    redis_retry_worker,
+)
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+@pytest.mark.anyio("asyncio")
+async def test_worker_registration_and_deregistration():
+    client = fakeredis.aioredis.FakeRedis(decode_responses=True)
+    coord = WorkerCoordinator(
+        client=client,
+        namespace="test-workers",
+        ttl_seconds=1,
+    )
+
+    await coord.register("worker-1", metadata={"role": "main"})
+    info = await coord.get_worker("worker-1")
+
+    assert info["worker_id"] == "worker-1"
+    assert info["status"] == "online"
+    assert "worker-1" in await coord.active_workers()
+
+    await coord.deregister("worker-1")
+    assert "worker-1" not in await coord.active_workers()
+
+
+@pytest.mark.anyio("asyncio")
+async def test_heartbeat_cleanup_removes_stale_workers():
+    client = fakeredis.aioredis.FakeRedis(decode_responses=True)
+    coord = WorkerCoordinator(
+        client=client,
+        namespace="ttl-workers",
+        ttl_seconds=0.05,
+    )
+
+    await coord.register("worker-ttl")
+    await asyncio.sleep(0.06)
+    removed = await coord.cleanup_stale()
+
+    assert "worker-ttl" in removed
+    assert "worker-ttl" not in await coord.active_workers()
+
+
+@pytest.mark.anyio("asyncio")
+async def test_graceful_shutdown_stops_retry_loop():
+    client = fakeredis.aioredis.FakeRedis(decode_responses=True)
+    store = RedisJobStore(client=client, namespace="retry-loop")
+    stop_event = asyncio.Event()
+
+    task = asyncio.create_task(
+        redis_retry_worker(
+            store=store,
+            poll_interval_ms=20,
+            shutdown_event=stop_event,
+        )
+    )
+
+    await asyncio.sleep(0.05)
+    stop_event.set()
+    await asyncio.wait_for(task, timeout=1.0)
+
+
+@pytest.mark.anyio("asyncio")
+async def test_queue_monitor_loop_stops_on_shutdown():
+    client = fakeredis.aioredis.FakeRedis(decode_responses=True)
+    store = RedisJobStore(client=client, namespace="queue-loop")
+    stop_event = asyncio.Event()
+
+    task = asyncio.create_task(
+        redis_queue_monitor_loop(
+            store=store,
+            poll_interval_ms=20,
+            shutdown_event=stop_event,
+        )
+    )
+
+    await asyncio.sleep(0.05)
+    stop_event.set()
+    await asyncio.wait_for(task, timeout=1.0)
+
+
+@pytest.mark.anyio("asyncio")
+async def test_multiple_workers_claim_jobs_without_conflict():
+    client = fakeredis.aioredis.FakeRedis(decode_responses=True)
+    store = RedisJobStore(client=client, namespace="claiming")
+
+    await store.set_state("job-claim", "enqueued")
+    first = await store.claim("job-claim")
+    second = await store.claim("job-claim")
+
+    assert first is True
+    assert second is False
+
+
+@pytest.mark.anyio("asyncio")
+async def test_worker_loop_respects_shutdown_event():
+    counter = {"ticks": 0}
+
+    async def run_once():
+        counter["ticks"] += 1
+
+    stop_event = asyncio.Event()
+    task = asyncio.create_task(
+        worker_loop(
+            run_once,
+            poll_interval_ms=20,
+            shutdown_event=stop_event,
+        )
+    )
+
+    await asyncio.sleep(0.05)
+    stop_event.set()
+    await asyncio.wait_for(task, timeout=1.0)
+    assert counter["ticks"] >= 1

--- a/tests/test_worker_orchestration_integration.py
+++ b/tests/test_worker_orchestration_integration.py
@@ -1,0 +1,82 @@
+import asyncio
+import time
+
+import fakeredis.aioredis
+import pytest
+
+from backend.workers.orchestration import WorkerCoordinator
+from backend.workers.redis_job_store import RedisJobStore
+from backend.workers.runner import runner_loop
+
+
+_results = []
+
+
+def _fake_job():
+    _results.append("ran")
+    return "ok"
+
+
+@pytest.fixture(autouse=True)
+def clear_results():
+    _results.clear()
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+@pytest.mark.anyio("asyncio")
+async def test_runner_loop_claims_exclusively_and_shuts_down():
+    client = fakeredis.aioredis.FakeRedis(decode_responses=True)
+    store = RedisJobStore(client=client, namespace="integration-jobs")
+    coord = WorkerCoordinator(
+        client=client,
+        namespace="integration-workers",
+        ttl_seconds=1,
+    )
+
+    await coord.register("worker-a")
+    await coord.register("worker-b")
+
+    job_id = "job-integration"
+    job_payload = {
+        "job_path": f"{__name__}._fake_job",
+        "args": [],
+        "kwargs": {},
+        "attempts": 0,
+    }
+
+    await store.set_last_job(job_id, job_payload)
+    await store.schedule_retry(job_id, int(time.time() * 1000) - 100)
+
+    shutdown_a = asyncio.Event()
+    shutdown_b = asyncio.Event()
+
+    task_a = asyncio.create_task(
+        runner_loop(
+            store=store,
+            shutdown_event=shutdown_a,
+            poll_interval_ms=20,
+        )
+    )
+    task_b = asyncio.create_task(
+        runner_loop(
+            store=store,
+            shutdown_event=shutdown_b,
+            poll_interval_ms=20,
+        )
+    )
+
+    await asyncio.sleep(0.1)
+    shutdown_a.set()
+    shutdown_b.set()
+    await asyncio.wait_for(asyncio.gather(task_a, task_b), timeout=2.0)
+
+    assert _results == ["ran"]
+    assert await store.get_state(job_id) == "done"
+
+    await coord.deregister("worker-a")
+    await coord.deregister("worker-b")
+    await coord.close()


### PR DESCRIPTION
Summary:
- Add worker entrypoint that registers with WorkerCoordinator, runs heartbeat, runs runner_loop with shutdown support, and deregisters on graceful shutdown.
- Propagate shutdown_event into runner/retry loops and ensure loops check it.
- Add tests: tests/test_entry_shutdown.py and tests/test_worker_orchestration_integration.py (fakeredis-backed).

Verification (local):
PYTHONPATH="$PWD" .venv/bin/pytest -q tests/test_entry_shutdown.py tests/test_worker_orchestration_integration.py tests/test_worker_orchestration.py
.venv/bin/flake8 backend/workers tests/test_entry_shutdown.py tests/test_worker_orchestration_integration.py

Notes:
- Scoped lint is clean on touched paths. Please run CI; squash-merge if green and no blocking reviews.