### PR TITLE
feat(brain): add WebSocket /ws/brain (auth handshake → runtime decision) + tests & docs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,6 +44,28 @@ jobs:
           PYTHONPATH="$PWD" python -c "import backend.brain.adapter"
           PYTHONPATH="$PWD" python -c "import backend.worker.runner"
 
+  brain-e2e:
+    runs-on: ubuntu-latest
+    needs: [backup-artifacts-check, payments-import-check, brain-import-check]
+    # Fast canary to validate brain runtime shim end-to-end in fake mode.
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.9"
+      - name: Install deps
+        run: |
+          pip install --upgrade pip
+          if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+          pip install pytest
+      - name: Run brain runtime e2e canary (fake mode)
+        env:
+          BRAIN_FAKE_MODE: "1"
+        run: |
+          PYTHONPATH="$PWD" pytest -q \
+            backend/brain/tests/test_brain_runtime_e2e.py \
+            backend/worker/tests/test_worker_brain_integration.py
+
   backup-artifacts-check:
     runs-on: ubuntu-latest
     steps:
@@ -91,7 +113,7 @@ jobs:
 
   test-backend:
     runs-on: ubuntu-latest
-    needs: [backup-artifacts-check, payments-import-check, brain-import-check]
+    needs: [backup-artifacts-check, payments-import-check, brain-import-check, brain-e2e]
     strategy:
       matrix:
         python-version: ["3.9"]
@@ -109,7 +131,7 @@ jobs:
 
   test-frontend:
     runs-on: ubuntu-latest
-    needs: [backup-artifacts-check, payments-import-check, brain-import-check]
+    needs: [backup-artifacts-check, payments-import-check, brain-import-check, brain-e2e]
     steps:
       - uses: actions/checkout@v4
       - name: Frontend tests placeholder
@@ -117,7 +139,7 @@ jobs:
 
   lint:
     runs-on: ubuntu-latest
-    needs: [backup-artifacts-check, payments-import-check, brain-import-check]
+    needs: [backup-artifacts-check, payments-import-check, brain-import-check, brain-e2e]
     steps:
       - uses: actions/checkout@v4
       - name: Lint placeholder
@@ -125,7 +147,7 @@ jobs:
 
   docker-build:
     runs-on: ubuntu-latest
-    needs: [backup-artifacts-check, payments-import-check, brain-import-check]
+    needs: [backup-artifacts-check, payments-import-check, brain-import-check, brain-e2e]
     steps:
       - uses: actions/checkout@v4
       - name: Build image
@@ -133,7 +155,7 @@ jobs:
 
   artifacts:
     runs-on: ubuntu-latest
-    needs: [backup-artifacts-check, payments-import-check, brain-import-check]
+    needs: [backup-artifacts-check, payments-import-check, brain-import-check, brain-e2e]
     steps:
       - uses: actions/checkout@v4
       - name: Upload reports

--- a/backend/api/ws/brain_ws.py
+++ b/backend/api/ws/brain_ws.py
@@ -1,0 +1,128 @@
+"""Brain decision WebSocket endpoint bridging to the runtime adapter."""
+from __future__ import annotations
+
+import contextlib
+from collections import defaultdict
+from typing import Any, Dict, Tuple
+
+from fastapi import APIRouter, Depends, WebSocket, WebSocketDisconnect
+
+from backend.schemas.auth import UserProfile
+from backend.security.deps import get_current_user_ws
+
+router = APIRouter()
+
+_ACTIVE_CONNECTIONS: set[WebSocket] = set()
+
+
+class _WsMetrics:
+    def __init__(self) -> None:
+        self.connects_total = 0
+        self.disconnects_total = 0
+        self.decisions_total: defaultdict[str, int] = defaultdict(int)
+
+    def inc_connect(self) -> None:
+        self.connects_total += 1
+
+    def inc_disconnect(self) -> None:
+        self.disconnects_total += 1
+
+    def inc_decision(self, action: str | None) -> None:
+        self.decisions_total[action or "unknown"] += 1
+
+
+METRICS = _WsMetrics()
+
+
+class _AdapterMetricsProxy:
+    def inc(self, name: str, labels: Any = None) -> None:
+        if name != "brain_decisions_total":
+            return
+        action = labels.get("action") if isinstance(labels, dict) else labels
+        METRICS.inc_decision(str(action or "unknown"))
+
+
+def _register(websocket: WebSocket) -> None:
+    _ACTIVE_CONNECTIONS.add(websocket)
+    METRICS.inc_connect()
+
+
+def _unregister(websocket: WebSocket) -> None:
+    _ACTIVE_CONNECTIONS.discard(websocket)
+    METRICS.inc_disconnect()
+
+
+def _normalize_payload(message: Any) -> Tuple[str, Dict[str, Any]]:
+    if not isinstance(message, dict):
+        return "", {}
+
+    request_id = str(message.get("request_id") or "")
+    snapshot = message.get("market_snapshot") or {}
+    if not isinstance(snapshot, dict):
+        snapshot = {}
+
+    normalized_signal = {
+        "type": snapshot.get("type", "market_snapshot"),
+        "provider_id": snapshot.get("provider_id", "ws"),
+        "strength": snapshot.get("strength", 0.0),
+        "confidence": snapshot.get("confidence", 0.5),
+        "timestamp": snapshot.get("timestamp", 0.0),
+        "metadata": snapshot.get("metadata") or snapshot,
+    }
+
+    return request_id, {"ws": normalized_signal}
+
+
+def _build_response(request_id: str, decision: Dict[str, Any]) -> Dict[str, Any]:
+    rationale = decision.get("rationale") or []
+    reason = rationale[0] if isinstance(rationale, list) and rationale else None
+    return {
+        "type": "brain-decision",
+        "request_id": request_id,
+        "action": decision.get("action"),
+        "confidence": decision.get("confidence"),
+        "reason": reason,
+        "meta": decision.get("meta") or {},
+    }
+
+
+async def _compute_decision(signals: Dict[str, Any]) -> Dict[str, Any]:
+    from backend.worker import runner
+
+    return runner.get_brain_decision(signals, metrics_client=_AdapterMetricsProxy())
+
+
+@router.websocket("/brain")
+async def brain_ws_endpoint(
+    websocket: WebSocket,
+    user: UserProfile = Depends(get_current_user_ws),
+) -> None:
+    """Authenticate, relay snapshot payloads to the brain, and stream decisions."""
+
+    await websocket.accept()
+    _register(websocket)
+    await websocket.send_json({"type": "brain-online", "detail": "ready"})
+
+    try:
+        while True:
+            message = await websocket.receive_json()
+            request_id, signals = _normalize_payload(message)
+
+            if not signals:
+                await websocket.send_json(
+                    {"type": "brain-error", "request_id": request_id, "detail": "invalid payload"}
+                )
+                continue
+
+            decision = await _compute_decision(signals)
+            response = _build_response(request_id, decision)
+            await websocket.send_json(response)
+    except WebSocketDisconnect:
+        pass
+    finally:
+        _unregister(websocket)
+        with contextlib.suppress(RuntimeError):
+            await websocket.close()
+
+
+__all__ = ["brain_ws_endpoint", "METRICS", "_normalize_payload"]

--- a/backend/brain/tests/test_brain_runtime_e2e.py
+++ b/backend/brain/tests/test_brain_runtime_e2e.py
@@ -1,0 +1,25 @@
+from backend.worker import runner
+
+
+class _StubMetrics:
+    def __init__(self):
+        self.calls = []
+
+    def inc(self, name, labels=None):
+        self.calls.append((name, labels))
+
+
+def test_brain_runtime_e2e_fake_mode(monkeypatch):
+    monkeypatch.setenv("BRAIN_FAKE_MODE", "1")
+    metrics = _StubMetrics()
+
+    decision = runner.get_brain_decision(
+        {"demo": {"type": "momentum", "strength": 0.3, "confidence": 0.6}},
+        config={"threshold": 0.25},
+        metrics_client=metrics,
+    )
+
+    assert decision["action"] == "hold"
+    assert 0.0 <= decision.get("confidence", 0.0) <= 1.0
+    assert isinstance(decision.get("meta", {}), dict)
+    assert ("brain_decisions_total", {"action": "hold"}) in metrics.calls

--- a/backend/docs/brain.md
+++ b/backend/docs/brain.md
@@ -58,4 +58,19 @@ print(decide({"demo": {"type": "momentum", "strength": 0.5, "confidence": 0.6}},
 PY
 ```
 
+## E2E validation & canary
+- Quick import guard: `PYTHONPATH="$PWD" BRAIN_FAKE_MODE=1 python -c "import backend.brain.adapter; import backend.worker.runner"`
+- Fast e2e runtime tests (fake mode): `PYTHONPATH="$PWD" BRAIN_FAKE_MODE=1 pytest -q backend/brain/tests -k e2e`
+- Worker smoke path: `PYTHONPATH="$PWD" BRAIN_FAKE_MODE=1 pytest -q backend/worker/tests -k brain_integration`
+- Metric to watch: `brain_decisions_total{action=...}` increments per decision; inject a metrics client with `inc(name, labels=...)` for tests and local runs.
+- `BRAIN_FAKE_MODE=1` keeps imports side-effect free and yields deterministic decisions for CI canaries.
+
+## Brain WebSocket (`/ws/brain`)
+- Auth: JWT via query param `token` or `Authorization: Bearer <token>`; handshake rejects with 4401 if missing/invalid.
+- Handshake: on connect sends `{ "type": "brain-online", "detail": "ready" }` after registering the connection.
+- Request payload: `{ "request_id": "uuid", "market_snapshot": { ... } }` where `market_snapshot` is a dict; missing/invalid payloads return `{ "type": "brain-error", "detail": "invalid payload" }`.
+- Routing: snapshot is normalized into a single signal and passed to `backend.worker.runner.get_brain_decision` (honors `BRAIN_FAKE_MODE`).
+- Response: `{ "type": "brain-decision", "request_id": "uuid", "action": str, "confidence": float, "reason": str, "meta": {...} }`.
+- Metrics: counters increment for connect/disconnect and decisions (via the adapter’s `brain_decisions_total{action=...}` path and a WebSocket-local tally).
+
 Note: Adapter is import-safe (no side effects on import); CI import guards must pass.

--- a/backend/main.py
+++ b/backend/main.py
@@ -14,9 +14,9 @@ from backend.api import (
     strategies,
 )
 from backend.api import admin_routes, auth_routes, payments
+from backend.api.ws.brain_ws import router as brain_ws_router
 from backend.api.ws.dashboard_ws import router as dashboard_ws_router
 from backend.api.websocket_router import router as websocket_router
-from backend.ws.brain_ws import router as brain_ws_router
 from backend.ws.signals_ws import router as signals_ws_router
 
 app = FastAPI(title="Bagbot Backend", version="0.1.0")

--- a/backend/worker/tests/test_worker_brain_integration.py
+++ b/backend/worker/tests/test_worker_brain_integration.py
@@ -1,0 +1,35 @@
+from backend.worker import runner
+
+
+class _StubMetrics:
+    def __init__(self):
+        self.calls = []
+
+    def inc(self, name, labels=None):
+        self.calls.append((name, labels))
+
+
+def _simulate_worker_job(signals, metrics):
+    # Minimal stand-in for a worker task that asks the brain for a decision.
+    decision = runner.get_brain_decision(signals, metrics_client=metrics)
+    # Worker would route/ack based on action; here we just return a shaped response.
+    return {
+        "decision": decision,
+        "routed": decision.get("action") not in {"hold", None},
+    }
+
+
+def test_worker_brain_integration_fake_mode(monkeypatch):
+    monkeypatch.setenv("BRAIN_FAKE_MODE", "1")
+    metrics = _StubMetrics()
+
+    result = _simulate_worker_job(
+        {"demo": {"type": "volatility", "strength": 0.2, "confidence": 0.7}},
+        metrics,
+    )
+
+    decision = result["decision"]
+    assert decision["action"] == "hold"
+    assert decision["meta"].get("source") == "fake"
+    assert result["routed"] is False
+    assert ("brain_decisions_total", {"action": "hold"}) in metrics.calls

--- a/tests/test_brain_ws.py
+++ b/tests/test_brain_ws.py
@@ -1,0 +1,87 @@
+"""Integration tests for the Brain WebSocket decision flow."""
+import os
+
+import pytest
+from fastapi.testclient import TestClient
+from starlette.websockets import WebSocketDisconnect
+
+os.environ.setdefault("BAGBOT_JWT_SECRET", "test-brain-secret")
+os.environ.setdefault("BRAIN_FAKE_MODE", "1")
+
+from backend.api.ws import brain_ws  # noqa: E402  pylint: disable=wrong-import-position
+from backend.main import app  # noqa: E402  pylint: disable=wrong-import-position
+from backend.security.jwt import create_access_token  # noqa: E402  pylint: disable=wrong-import-position
+
+
+@pytest.fixture(autouse=True)
+def _reset_state():
+    brain_ws.METRICS.connects_total = 0
+    brain_ws.METRICS.disconnects_total = 0
+    brain_ws.METRICS.decisions_total.clear()
+    brain_ws._ACTIVE_CONNECTIONS.clear()
+    yield
+
+
+@pytest.fixture()
+def client() -> TestClient:
+    return TestClient(app)
+
+
+@pytest.fixture()
+def auth_token() -> str:
+    claims = {
+        "id": "user-brain",
+        "name": "Brain WS Tester",
+        "email": "brain@test.io",
+        "role": "admin",
+    }
+    return create_access_token(claims)
+
+
+def test_brain_ws_requires_token(client: TestClient) -> None:
+    with pytest.raises(WebSocketDisconnect) as excinfo:
+        with client.websocket_connect("/ws/brain"):
+            pass
+
+    assert excinfo.value.code == 4401
+
+
+def test_brain_ws_handshake_and_decision_flow(client: TestClient, auth_token: str) -> None:
+    with client.websocket_connect(f"/ws/brain?token={auth_token}") as websocket:
+        handshake = websocket.receive_json()
+        assert handshake["type"] == "brain-online"
+
+        payload = {
+            "request_id": "req-1",
+            "market_snapshot": {
+                "type": "momentum",
+                "strength": 0.3,
+                "confidence": 0.7,
+                "metadata": {"span": "1m"},
+            },
+        }
+        websocket.send_json(payload)
+
+        response = websocket.receive_json()
+        assert response["type"] == "brain-decision"
+        assert response["request_id"] == payload["request_id"]
+        assert response["action"] == "hold"
+        assert response["confidence"] == 0.5
+        assert response["reason"] == "fake_mode enabled"
+
+        assert brain_ws.METRICS.connects_total == 1
+        assert brain_ws.METRICS.decisions_total["hold"] == 1
+
+    assert brain_ws.METRICS.disconnects_total == 1
+    assert len(brain_ws._ACTIVE_CONNECTIONS) == 0
+
+
+def test_brain_ws_handles_invalid_payload(client: TestClient, auth_token: str) -> None:
+    with client.websocket_connect(f"/ws/brain?token={auth_token}") as websocket:
+        _ = websocket.receive_json()  # handshake
+
+        websocket.send_json("oops")
+        error = websocket.receive_json()
+
+        assert error["type"] == "brain-error"
+        assert error["detail"] == "invalid payload"


### PR DESCRIPTION
## Summary
- add auth-protected `/ws/brain` websocket that normalizes snapshot payloads and routes to `runner.get_brain_decision` with fake-mode safety
- send handshake (`brain-online`), relay decisions (`brain-decision`), and surface errors for bad payloads; track connect/disconnect/decision counters
- add WS + adapter/runtime tests and document the flow in `backend/docs/brain.md`

## Files
- endpoint: `backend/api/ws/brain_ws.py` wired via `backend/main.py`
- tests: `tests/test_brain_ws.py`, `backend/brain/tests/test_brain_runtime_e2e.py`, `backend/worker/tests/test_worker_brain_integration.py`
- docs: `backend/docs/brain.md`
- CI: `.github/workflows/ci.yml` (brain-e2e canary stays gating)

## Verification
- PYTHONPATH="$PWD" BRAIN_FAKE_MODE=1 python -c "import backend.brain.adapter"
- PYTHONPATH="$PWD" BRAIN_FAKE_MODE=1 python -c "import backend.worker.runner"
- PYTHONPATH="$PWD" python -m pytest -q tests/test_brain_ws.py                        → 3 passed, 1 warning
- PYTHONPATH="$PWD" BRAIN_FAKE_MODE=1 python -m pytest -q backend/brain/tests -k adapter   → 3 passed, 1 deselected, warnings: 2
- PYTHONPATH="$PWD" BRAIN_FAKE_MODE=1 python -m pytest -q -k "brain and runtime"          → 3 passed, 463 deselected, warnings: 3
- PYTHONPATH="$PWD" python -m pytest -q -k payments                                      → 27 passed, 439 deselected, warnings: 3

## Checklist
- [ ] Unit tests pass in CI
- [ ] Import-check jobs (brain-import-check / brain-runtime-check) pass first
- [ ] Staging verification needed
