### PR TITLE
feat(brain): add multi-provider orchestrator (import-safe) + tests & docs

### DIFF
--- a/backend/brain/orchestrator/__init__.py
+++ b/backend/brain/orchestrator/__init__.py
@@ -1,0 +1,8 @@
+"""Multi-provider orchestrator (import-safe, deterministic).
+
+Public entrypoint: orchestrate_providers(payload, *, metrics_client=None, fake_mode=None).
+"""
+
+from .core import orchestrate_providers
+
+__all__ = ["orchestrate_providers"]

--- a/backend/brain/orchestrator/core.py
+++ b/backend/brain/orchestrator/core.py
@@ -1,0 +1,92 @@
+from __future__ import annotations
+
+import os
+from typing import Any, Dict, List, Tuple
+
+from .providers import PROVIDER_FUNCS, _fake_mode_enabled
+from .schema import OrchestratorResult, ProviderSignal, clamp_confidence
+
+
+def _inc(metrics_client: Any, name: str, labels: Dict[str, Any]) -> None:
+    if not metrics_client:
+        return
+    inc = getattr(metrics_client, "inc", None) or getattr(metrics_client, "increment", None)
+    if not callable(inc):
+        return
+    try:
+        inc(name, labels=labels)
+    except Exception:
+        return
+
+
+def _select_best(signals: List[ProviderSignal]) -> ProviderSignal:
+    # Deterministic: sort by confidence desc, then provider_id asc.
+    return sorted(signals, key=lambda s: (-s.confidence, s.provider_id))[0]
+
+
+def orchestrate_providers(
+    payload: Dict[str, Any],
+    *,
+    metrics_client: Any = None,
+    fake_mode: bool | None = None,
+) -> Dict[str, Any]:
+    env = os.environ
+    use_fake = _fake_mode_enabled(env) if fake_mode is None else bool(fake_mode)
+
+    _inc(metrics_client, "brain_orchestrator_requests_total", {})
+
+    signals: List[ProviderSignal] = []
+    failures: List[str] = []
+
+    for provider_id, func in PROVIDER_FUNCS.items():
+        try:
+            sig = func(payload, env=env)
+            signals.append(sig)
+            _inc(metrics_client, "brain_orchestrator_provider_success_total", {"provider": provider_id})
+        except Exception:
+            failures.append(provider_id)
+            _inc(metrics_client, "brain_orchestrator_provider_failure_total", {"provider": provider_id})
+
+    if not signals:
+        result = OrchestratorResult(
+            action="hold",
+            confidence=0.3,
+            provider="none",
+            rationale=["no_providers_available"],
+            meta={"signals_used": [], "failed_providers": failures, "fake_mode": use_fake},
+        )
+        _inc(metrics_client, "brain_orchestrator_decisions_total", {"action": result.action})
+        return {
+            "action": result.action,
+            "confidence": result.confidence,
+            "rationale": result.rationale,
+            "meta": result.meta,
+        }
+
+    best = _select_best(signals)
+    confidence = clamp_confidence(best.confidence)
+    rationale = best.rationale or [f"selected:{best.provider_id}"]
+
+    result = OrchestratorResult(
+        action=best.action or "hold",
+        confidence=confidence,
+        provider=best.provider_id,
+        rationale=rationale,
+        meta={
+            "signals_used": [s.provider_id for s in signals],
+            "failed_providers": failures,
+            "fake_mode": use_fake,
+        },
+    )
+
+    _inc(metrics_client, "brain_orchestrator_decisions_total", {"action": result.action})
+
+    return {
+        "action": result.action,
+        "confidence": result.confidence,
+        "rationale": result.rationale,
+        "meta": result.meta,
+    }
+
+
+__all__ = ["orchestrate_providers"]

--- a/backend/brain/orchestrator/providers.py
+++ b/backend/brain/orchestrator/providers.py
@@ -1,0 +1,85 @@
+from __future__ import annotations
+
+import hashlib
+from typing import Any, Dict, List
+
+from .schema import ProviderSignal, clamp_confidence
+
+_FAKE_VALUES = {"1", "true", "yes", "on"}
+
+
+def _fake_mode_enabled(env: Dict[str, str]) -> bool:
+    return env.get("BRAIN_FAKE_MODE", "").strip().lower() in _FAKE_VALUES
+
+
+def _hash_payload(payload: Dict[str, Any]) -> int:
+    if not payload:
+        return 0
+    raw = repr(sorted(payload.items())).encode()
+    return int(hashlib.sha256(raw).hexdigest(), 16)
+
+
+def tradingview_provider(payload: Dict[str, Any], *, env: Dict[str, str]) -> ProviderSignal:
+    fake = _fake_mode_enabled(env)
+    confidence = 0.7 if fake else 0.65
+    return ProviderSignal(
+        provider_id="tradingview",
+        action="buy",
+        confidence=clamp_confidence(confidence),
+        strength=0.6,
+        rationale=["tv:trend_up"],
+        raw=payload or {},
+    )
+
+
+def indicators_provider(payload: Dict[str, Any], *, env: Dict[str, str]) -> ProviderSignal:
+    fake = _fake_mode_enabled(env)
+    h = _hash_payload(payload)
+    confidence = 0.6 if fake else 0.55 + (h % 5) * 0.01
+    action = "buy" if (h % 3) == 0 else "hold"
+    return ProviderSignal(
+        provider_id="indicators",
+        action=action,
+        confidence=clamp_confidence(confidence),
+        strength=0.5,
+        rationale=["ind:oscillator_mix"],
+        raw=payload or {},
+    )
+
+
+def brain_provider(payload: Dict[str, Any], *, env: Dict[str, str]) -> ProviderSignal:
+    # Import inside function to keep import-safety and avoid adapter side effects when unused.
+    from backend.brain import adapter
+
+    fake = _fake_mode_enabled(env)
+    decision = adapter.decide({"ws": payload or {}}, fake_mode=fake)
+    rationale: List[str] = decision.get("rationale") or []
+    return ProviderSignal(
+        provider_id="brain",
+        action=decision.get("action") or "hold",
+        confidence=clamp_confidence(float(decision.get("confidence", 0.5))),
+        strength=0.5,
+        rationale=rationale,
+        raw=payload or {},
+    )
+
+
+def marketdata_provider(payload: Dict[str, Any], *, env: Dict[str, str]) -> ProviderSignal:
+    fake = _fake_mode_enabled(env)
+    confidence = 0.5 if fake else 0.52
+    return ProviderSignal(
+        provider_id="marketdata",
+        action="hold",
+        confidence=clamp_confidence(confidence),
+        strength=0.4,
+        rationale=["md:neutral_depth"] if fake else ["md:low_vol"],
+        raw=payload or {},
+    )
+
+
+PROVIDER_FUNCS = {
+    "tradingview": tradingview_provider,
+    "indicators": indicators_provider,
+    "brain": brain_provider,
+    "marketdata": marketdata_provider,
+}

--- a/backend/brain/orchestrator/schema.py
+++ b/backend/brain/orchestrator/schema.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Dict, List, Optional
+
+
+@dataclass
+class ProviderSignal:
+    provider_id: str
+    action: str
+    confidence: float
+    strength: float
+    rationale: List[str]
+    raw: Dict[str, Any]
+
+
+@dataclass
+class OrchestratorResult:
+    action: str
+    confidence: float
+    provider: str
+    rationale: List[str]
+    meta: Dict[str, Any]
+
+
+def clamp_confidence(value: float) -> float:
+    if value < 0:
+        return 0.0
+    if value > 1:
+        return 1.0
+    return value

--- a/backend/docs/brain_orchestrator.md
+++ b/backend/docs/brain_orchestrator.md
@@ -1,0 +1,53 @@
+# Brain Multi-Provider Orchestrator
+
+## Purpose
+A deterministic, import-safe orchestrator that gathers signals from multiple simulated providers and selects the best decision. No network/FS/Redis/Stripe is touched on import; everything is pure and local. Runtime wiring will call `orchestrate_providers` later.
+
+## API
+```
+from backend.brain.orchestrator import orchestrate_providers
+
+result = orchestrate_providers(payload: dict, *, metrics_client=None, fake_mode: bool | None = None)
+```
+
+### Input
+- `payload`: arbitrary dict to pass to providers.
+- `metrics_client` (optional): object with `inc(name, labels=...)` or `increment(...)`.
+- `fake_mode`: overrides env; otherwise respects `BRAIN_FAKE_MODE`.
+
+### Output shape
+```
+{
+  "action": str,            # e.g. "buy" | "hold" | "sell"
+  "confidence": float,      # clamped 0..1
+  "rationale": [str],
+  "meta": {
+    "signals_used": [provider_ids...],
+    "failed_providers": [provider_ids...],
+    "fake_mode": bool
+  }
+}
+```
+
+## Provider fusion logic
+- Providers: `tradingview`, `indicators`, `brain`, `marketdata` (all simulated/deterministic).
+- Each returns a normalized signal `{provider_id, action, confidence, strength, rationale}`.
+- Selection: pick highest confidence; tie-break alphabetically by `provider_id` for determinism.
+- Fallback: if all providers fail, return `hold` with rationale `no_providers_available` and list failures.
+
+## Fake-mode behavior
+- Controlled by `BRAIN_FAKE_MODE` env or `fake_mode=True` arg.
+- Providers return canned deterministic signals; no external calls.
+- Keeps import safety and CI determinism.
+
+## Metrics (injected)
+If `metrics_client` supplied:
+- `brain_orchestrator_requests_total`
+- `brain_orchestrator_provider_success_total{provider=...}`
+- `brain_orchestrator_provider_failure_total{provider=...}`
+- `brain_orchestrator_decisions_total{action=...}`
+
+## Runtime integration (later)
+- Runtime services can call `orchestrate_providers(payload, metrics_client=...)`.
+- Keep `metrics_client` injectable (no globals).
+- Respect fake mode for canaries/CI; real providers can be wired behind these functions without changing the selection API.

--- a/tests/test_brain_orchestrator.py
+++ b/tests/test_brain_orchestrator.py
@@ -1,0 +1,93 @@
+"""Unit tests for the multi-provider orchestrator (offline, deterministic)."""
+import os
+
+import pytest
+
+os.environ.setdefault("BAGBOT_JWT_SECRET", "test-secret")
+os.environ.setdefault("BRAIN_FAKE_MODE", "1")
+
+from backend.brain.orchestrator import orchestrate_providers  # noqa: E402  pylint: disable=wrong-import-position
+
+
+class _StubMetrics:
+    def __init__(self):
+        self.calls = []
+
+    def inc(self, name, labels=None):  # type: ignore[override]
+        self.calls.append((name, labels or {}))
+
+
+def _metrics_count(calls, name, label_key=None, label_value=None):
+    return sum(
+        1
+        for n, lbl in calls
+        if n == name and (label_key is None or lbl.get(label_key) == label_value)
+    )
+
+
+def test_fake_mode_deterministic_decision():
+    result = orchestrate_providers({"foo": "bar"}, fake_mode=True)
+
+    assert result["action"] in {"buy", "hold"}
+    assert 0.0 <= result["confidence"] <= 1.0
+    assert result["meta"]["fake_mode"] is True
+
+
+def test_provider_failure_fallback(monkeypatch):
+    # Force indicators to fail and ensure others still decide.
+    from backend.brain.orchestrator import providers
+
+    def boom(payload, env=None):
+        raise ValueError("boom")
+
+    monkeypatch.setattr(providers, "indicators_provider", boom)
+    monkeypatch.setitem(providers.PROVIDER_FUNCS, "indicators", boom)
+
+    result = orchestrate_providers({}, fake_mode=True)
+
+    assert result["action"] in {"buy", "hold"}
+    assert "indicators" in result["meta"]["failed_providers"]
+    assert "indicators" not in result["meta"]["signals_used"]
+
+
+def test_confidence_selection_tiebreak(monkeypatch):
+    from backend.brain.orchestrator import providers
+
+    def p1(payload, env=None):
+        from backend.brain.orchestrator.schema import ProviderSignal
+
+        return ProviderSignal("a", "buy", 0.7, 0.4, ["a"], {})
+
+    def p2(payload, env=None):
+        from backend.brain.orchestrator.schema import ProviderSignal
+
+        return ProviderSignal("b", "sell", 0.7, 0.4, ["b"], {})
+
+    monkeypatch.setattr(providers, "tradingview_provider", p1)
+    monkeypatch.setattr(providers, "indicators_provider", p2)
+    monkeypatch.setitem(providers.PROVIDER_FUNCS, "tradingview", p1)
+    monkeypatch.setitem(providers.PROVIDER_FUNCS, "indicators", p2)
+
+    result = orchestrate_providers({}, fake_mode=True)
+
+    assert result["action"] == "buy"  # provider_id 'a' wins tie (alphabetical)
+    # Signals used reflect provider_ids from returned signals.
+    assert result["meta"]["signals_used"] == ["a", "b", "brain", "marketdata"]
+
+
+def test_metrics_injection():
+    metrics = _StubMetrics()
+
+    orchestrate_providers({}, fake_mode=True, metrics_client=metrics)
+
+    assert _metrics_count(metrics.calls, "brain_orchestrator_requests_total") == 1
+    assert _metrics_count(metrics.calls, "brain_orchestrator_decisions_total") == 1
+    assert _metrics_count(metrics.calls, "brain_orchestrator_provider_success_total") >= 1
+
+
+def test_import_safe():
+    # Simply importing should not raise or do side effects.
+    import importlib
+
+    module = importlib.import_module("backend.brain.orchestrator")
+    assert hasattr(module, "orchestrate_providers")


### PR DESCRIPTION
Summary
=======
Adds a backend-only, import-safe multi-provider orchestrator for the Brain. The module provides simulated providers and deterministic fusion.

What changed
- backend/brain/orchestrator/: core orchestrator, providers (simulated), schema
- backend/docs/brain_orchestrator.md: design, API, fake-mode, metrics
- tests/test_brain_orchestrator.py: unit + import-safety tests

Local verification (done)
- Import safety: BRAIN_FAKE_MODE=1 import backend.brain.orchestrator -> pass
- Unit tests: pytest tests/test_brain_orchestrator.py -> 5 passed

Checklist
- [x] Branch pushed: feat/brain-orchestrator
- [ ] Import-safety check performed in PR CI (BRAIN_FAKE_MODE=1)
- [ ] tests/test_brain_orchestrator.py passes in CI
- [ ] Add label `area/brain`
- [ ] Request backend/brain reviewers (please assign backend owners)
- [ ] If staging cannot be run from here, add label `needs-staging-verification`

Notes
- This is backend-only; no runtime wiring was added.
- The orchestrator is deterministic in fake mode and side-effect free on import.
