### PR TITLE
chore(brain): post-merge verification & staging request for orchestrator

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,0 +1,3 @@
+# Changelog
+
+- 2025-12-10: feat(brain): add orchestrator runtime shim and tests (imports guarded, fake-mode supported)

--- a/docs/postmerge/PR-46-verify.md
+++ b/docs/postmerge/PR-46-verify.md
@@ -1,0 +1,30 @@
+# Post-merge verification for brain orchestrator runtime (PR #46 already merged)
+
+Summary
+- Runtime shim and orchestrator merged in PR #46.
+- This note captures local quick checks and a staging verification ask for ops/QA.
+
+Quick checks performed locally
+- Import: PYTHONPATH="$PWD" BRAIN_FAKE_MODE=1 python -c "import backend.brain.orchestrator" -> PASS
+- Import: PYTHONPATH="$PWD" BRAIN_FAKE_MODE=1 python -c "import backend.brain.adapter" -> PASS
+- Adapter tests: pytest -q backend/brain/tests -k adapter -> PASS
+- Runtime tests: pytest -q -k "brain and runtime" -> PASS
+- Payments slice: pytest -q -k payments -> PASS
+
+Staging verification ask (ops/QA)
+1) Deploy the staging build for commit <insert commit sha here> (or current main).
+2) Start a worker with BRAIN_FAKE_MODE=1.
+3) Connect to /ws/brain and perform handshake + 3 decision requests.
+4) Confirm metrics in staging (snapshot):
+   - brain_orchestrator_requests_total{outcome="success"} increment
+   - brain_orchestrator_decision_total{action=...} values
+   - brain_decisions_total{action=...} from adapter
+5) Reply in PR with a short snippet: timestamp + metric values or "STAGING OK".
+
+Checklist
+- [ ] CI import-checks (brain-import-check & brain-e2e) pass
+- [ ] Ops/QA confirm staging canary OR we label needs-staging-verification
+- [ ] Add one-liner to CHANGELOG after staging OK
+
+Notes
+- The original PR #46 remains merged; this follow-up is for verification and ops sign-off.


### PR DESCRIPTION
Post-merge verification for the brain orchestrator runtime (PR #46 already merged).\n\nSummary\n- Runtime shim and orchestrator merged in PR #46.\n- This PR contains only docs/changelog and a verification note so ops/QA can run staging canary.\n\nQuick checks performed locally\n- Import: PYTHONPATH="/Users/bagumadavis/Desktop/bagbot/_worktrees/feat-brain-e2e" BRAIN_FAKE_MODE=1 python3 -c "import backend.brain.orchestrator" -> PASS\n- Import: PYTHONPATH="/Users/bagumadavis/Desktop/bagbot/_worktrees/feat-brain-e2e" BRAIN_FAKE_MODE=1 python3 -c "import backend.brain.adapter" -> PASS\n- Adapter tests: pytest -q backend/brain/tests -k adapter -> 3 passed, 5 deselected, 2 warnings in 6.27s\n- Runtime tests: pytest -q -k "brain and runtime" -> 3 passed, 468 deselected, 3 warnings in 5.94s\n- Payments slice: pytest -q -k payments -> 27 passed, 444 deselected, 3 warnings in 8.75s\n\nWhat I need from ops/QA (staging verification)\n1) Deploy the staging build for commit <insert commit sha here> (or current main).\n2) Start a worker with BRAIN_FAKE_MODE=1.\n3) Connect to /ws/brain and perform: handshake + 3 decision requests.\n4) Confirm metrics in staging (snapshot) — look for: brain_orchestrator_requests_total{outcome="success"} increment; brain_orchestrator_decision_total{action=...} values; brain_decisions_total{action=...} from adapter.\n5) Reply in this PR with a short snippet: timestamp + metric values or "STAGING OK".\n\nChecklist\n- [ ] CI import-checks (brain-import-check & brain-e2e) pass\n- [ ] Ops/QA confirm staging canary OR we keep label needs-staging-verification\n- [ ] Add one-liner to CHANGELOG after staging OK\n\nNotes\n- Original PR #46 remains merged; this follow-up is for verification and ops sign-off only.